### PR TITLE
Fix deprecated syntax @doc

### DIFF
--- a/src/ma.jl
+++ b/src/ma.jl
@@ -1,26 +1,27 @@
-@doc """
-Simple moving average (SMA)
+"""
+    sma(x::Array{Float64}; n::Int64=10)::Array{Float64}
 
-`sma(x::Array{Float64}; n::Int64=10)::Array{Float64}`
-""" ->
+Simple moving average (SMA)
+"""
 function sma(x::Array{Float64}; n::Int64=10)::Array{Float64}
     return runmean(x, n=n, cumulative=false)
 end
 
-@doc """
-Triangular moving average (TRIMA)
+"""
+    trima(x::Array{Float64}; n::Int64=10, ma::Function=sma, args...)::Array{Float64}
 
-`trima(x::Array{Float64}; n::Int64=10, ma::Function=sma, args...)::Array{Float64}`
-""" ->
+
+Triangular moving average (TRIMA)
+"""
 function trima(x::Array{Float64}; n::Int64=10, ma::Function=sma)::Array{Float64}
     return ma(ma(x, n=n), n=n)
 end
 
-@doc """
-Weighted moving average (WMA)
+"""
+    wma(x::Array{Float64}; n::Int64=10, wts::Array{Float64}=collect(1:n)/sum(1:n))::Array{Float64}
 
-`wma(x::Array{Float64}; n::Int64=10, wts::Array{Float64}=collect(1:n)/sum(1:n))::Array{Float64}`
-""" ->
+Weighted moving average (WMA)
+"""
 function wma(x::Array{Float64}; n::Int64=10, wts::Array{Float64}=collect(1:n)/sum(1:n))
     @assert n<size(x,1) && n>0 "Argument n out of bounds"
     out = fill(NaN, size(x,1))
@@ -43,11 +44,11 @@ function first_valid(x::Array{Float64})::Int
     return 0
 end
 
-@doc """
-Exponential moving average (EMA)
+"""
+    ema(x::Array{Float64}; n::Int64=10, alpha::Float64=2.0/(n+1.0), wilder::Bool=false)::Array{Float64}
 
-`ema(x::Array{Float64}; n::Int64=10, alpha::Float64=2.0/(n+1.0), wilder::Bool=false)::Array{Float64}`
-""" ->
+Exponential moving average (EMA)
+"""
 function ema(x::Array{Float64}; n::Int64=10, alpha::Float64=2.0/(n+1), wilder::Bool=false)
     @assert n<size(x,1) && n>0 "Argument n out of bounds."
     if wilder
@@ -63,31 +64,31 @@ function ema(x::Array{Float64}; n::Int64=10, alpha::Float64=2.0/(n+1), wilder::B
     return out
 end
 
-@doc """
-Modified moving average (MMA)
+"""
+    mma(x::Array{Float64}; n::Int64=10)::Array{Float64}
 
-`mma(x::Array{Float64}; n::Int64=10)::Array{Float64}`
-""" ->
+Modified moving average (MMA)
+"""
 function mma(x::Array{Float64}; n::Int64=10)
     return ema(x, n=n, alpha=1.0/n)
 end
 
-@doc """
-Double exponential moving average (DEMA)
+"""
+    dema(x::Array{Float64}; n::Int64=10, alpha=2.0/(n+1), wilder::Bool=false)::Array{Float64}
 
-`dema(x::Array{Float64}; n::Int64=10, alpha=2.0/(n+1), wilder::Bool=false)::Array{Float64}`
-""" ->
+Double exponential moving average (DEMA)
+"""
 function dema(x::Array{Float64}; n::Int64=10, alpha=2.0/(n+1), wilder::Bool=false)
     return 2.0 * ema(x, n=n, alpha=alpha, wilder=wilder) - 
         ema(ema(x, n=n, alpha=alpha, wilder=wilder),
             n=n, alpha=alpha, wilder=wilder)
 end
 
-@doc """
-Triple exponential moving average (TEMA)
+"""
+    tema(x::Array{Float64}; n::Int64=10, alpha=2.0/(n+1), wilder::Bool=false)::Array{Float64}
 
-`tema(x::Array{Float64}; n::Int64=10, alpha=2.0/(n+1), wilder::Bool=false)::Array{Float64}`
-""" ->
+Triple exponential moving average (TEMA)
+"""
 function tema(x::Array{Float64}; n::Int64=10, alpha=2.0/(n+1), wilder::Bool=false)
     return 3.0 * ema(x, n=n, alpha=alpha, wilder=wilder) - 
         3.0 * ema(ema(x, n=n, alpha=alpha, wilder=wilder),
@@ -97,11 +98,11 @@ function tema(x::Array{Float64}; n::Int64=10, alpha=2.0/(n+1), wilder::Bool=fals
             n=n, alpha=alpha, wilder=wilder)
 end
 
-@doc """
-MESA adaptive moving average (MAMA)
+"""
+    mama(x::Array{Float64}; fastlimit::Float64=0.5, slowlimit::Float64=0.05)::Matrix{Float64}
 
-`mama(x::Array{Float64}; fastlimit::Float64=0.5, slowlimit::Float64=0.05)::Matrix{Float64}`
-""" ->
+MESA adaptive moving average (MAMA)
+"""
 function mama(x::Array{Float64}; fastlimit::Float64=0.5, slowlimit::Float64=0.05)::Matrix{Float64}
     n = size(x,1)
     out = zeros(Float64, n, 2)
@@ -262,18 +263,18 @@ function mama(x::Array{Float64}; fastlimit::Float64=0.5, slowlimit::Float64=0.05
 end
 
 
-@doc """
-Hull moving average (HMA)
+"""
+    hma(x::Array{Float64}; n::Int64=20)::Array{Float64}
 
-`hma(x::Array{Float64}; n::Int64=20)::Array{Float64}`
-""" ->
+Hull moving average (HMA)
+"""
 function hma(x::Array{Float64}; n::Int64=20)
     return wma(2 * wma(x, n=Int64(round(n/2.0))) - wma(x, n=n), n=Int64(trunc(sqrt(n))))
 end
 
-@doc """
+"""
 Sine-weighted moving average
-""" ->
+"""
 function swma(x::Array{Float64}; n::Int64=10)
     @assert n<size(x,1) && n>0 "Argument n out of bounds."
     w = sin.(collect(1:n) * 180.0/6.0)  # numerator weights
@@ -286,9 +287,9 @@ function swma(x::Array{Float64}; n::Int64=10)
     return out
 end
 
-@doc """
+"""
 Kaufman adaptive moving average (KAMA)
-""" ->
+"""
 function kama(x::Array{Float64}; n::Int64=10, nfast::Float64=0.6667, nslow::Float64=0.0645)
     @assert n<size(x,1) && n>0 "Argument n out of bounds."
     @assert nfast>0.0 && nfast<1.0 "Argument nfast out of bounds."
@@ -309,11 +310,11 @@ function kama(x::Array{Float64}; n::Int64=10, nfast::Float64=0.6667, nslow::Floa
     return out
 end
 
-@doc """
-Arnaud-Legoux moving average (ALMA)
+"""
+    alma{Float64}(x::Array{Float64}; n::Int64=9, offset::Float64=0.85, sigma::Float64=6.0)::Array{Float64}
 
-`alma{Float64}(x::Array{Float64}; n::Int64=9, offset::Float64=0.85, sigma::Float64=6.0)::Array{Float64}`
-""" ->
+Arnaud-Legoux moving average (ALMA)
+"""
 function alma(x::Array{Float64}; n::Int64=9, offset::Float64=0.85, sigma::Float64=6.0)
     @assert n<size(x,1) && n>0 "Argument n out of bounds."
     @assert sigma>0.0 "Argument sigma must be greater than 0."
@@ -343,11 +344,11 @@ function lagged(x::Array{Float64}, n::Int=1)::Array{Float64}
     end
 end
 
-@doc """
-Zero-lag exponential moving average (ZLEMA)
+"""
+    zlema(x::Array{Float64}; n::Int=10, ema_args...)::Array{Float64}
 
-`zlema(x::Array{Float64}; n::Int=10, ema_args...)::Array{Float64}`
-""" ->
+Zero-lag exponential moving average (ZLEMA)
+"""
 function zlema(x::Array{Float64}; n::Int=10, ema_args...)::Array{Float64}
     return ema(x+(x-lagged(x,round(Int, (n-1)/2.0))), n=n; ema_args...)
 end

--- a/src/mom.jl
+++ b/src/mom.jl
@@ -1,16 +1,16 @@
 # Momentum-oriented technical indicator functions
 
-@doc """
-Aroon up/down/oscillator
+"""
+    aroon(hl::Array{Float64,2}; n::Int64=25)::Array{Float64}
 
-`aroon(hl::Array{Float64,2}; n::Int64=25)::Array{Float64}`
+Aroon up/down/oscillator
 
 *Output*
 
 - Column 1: Aroon Up
 - Column 2: Aroon Down
 - Column 3: Aroon Oscillator
-""" ->
+"""
 function aroon(hl::Array{Float64,2}; n::Int64=25)::Matrix{Float64}
     @assert size(hl,2) == 2 "Argument `hl` must have exactly 2 columns."
     @assert n < size(hl,1) "Argument `n` must be less than the number of rows in argument `hl`."
@@ -26,17 +26,17 @@ function aroon(hl::Array{Float64,2}; n::Int64=25)::Matrix{Float64}
     return out
 end
 
-@doc """
-Donchian channel (if inclusive is set to true, will include current bar in calculations.)
+"""
+    donch(hl::Array{Float64,2}; n::Int64=10, inclusive::Bool=true)::Array{Float64}
 
-`donch(hl::Array{Float64,2}; n::Int64=10, inclusive::Bool=true)::Array{Float64}`
+Donchian channel (if inclusive is set to true, will include current bar in calculations.)
 
 *Output*
 
 - Column 1: Lowest low of last `n` periods
 - Column 2: Average of highest high and lowest low of last `n` periods
 - Column 3: Highest high of last `n` periods
-""" ->
+"""
 function donch(hl::Array{Float64,2}; n::Int64=10, inclusive::Bool=true)::Matrix{Float64}
     @assert size(hl,2) == 2 "Argument `hl` must have exactly 2 columns."
     local lower::Array{Float64} = runmin(hl[:,2], n=n, cumulative=false, inclusive=inclusive)
@@ -45,21 +45,21 @@ function donch(hl::Array{Float64,2}; n::Int64=10, inclusive::Bool=true)::Matrix{
     return [lower middle upper]
 end
 
-@doc """
-Momentum indicator (price now vs price `n` periods back)
+"""
+    momentum(x::Array{Float64}; n::Int64=1)::Array{Float64}
 
-`momentum(x::Array{Float64}; n::Int64=1)::Array{Float64}`
-""" ->
+Momentum indicator (price now vs price `n` periods back)
+"""
 function momentum(x::Array{Float64}; n::Int64=1)::Array{Float64}
     @assert n>0 "Argument n must be positive."
     return diffn(x, n=n)
 end
 
-@doc """
-Rate of change indicator (percent change between i'th observation and (i-n)'th observation)
+"""
+    roc(x::Array{Float64}; n::Int64=1)::Array{Float64}
 
-`roc(x::Array{Float64}; n::Int64=1)::Array{Float64}`
-""" ->
+Rate of change indicator (percent change between i'th observation and (i-n)'th observation)
+"""
 function roc(x::Array{Float64}; n::Int64=1)::Array{Float64}
     @assert n<size(x,1) && n>0 "Argument n out of bounds."
     out = zeros(size(x))
@@ -70,17 +70,17 @@ function roc(x::Array{Float64}; n::Int64=1)::Array{Float64}
     return out * 100.0
 end
 
-@doc """
-Moving average convergence-divergence
+"""
+    macd(x::Array{Float64}; nfast::Int64=12, nslow::Int64=26, nsig::Int64=9)::Array{Float64}
 
-`macd(x::Array{Float64}; nfast::Int64=12, nslow::Int64=26, nsig::Int64=9)::Array{Float64}`
+Moving average convergence-divergence
 
 *Output*
 
 - Column 1: MACD
 - Column 2: MACD Signal Line
 - Column 3: MACD Histogram
-""" ->
+"""
 function macd(x::Array{Float64}; nfast::Int64=12, nslow::Int64=26, nsig::Int64=9,
               fastMA::Function=ema, slowMA::Function=ema, signalMA::Function=sma)::Matrix{Float64}
     out = zeros(Float64, (length(x),3))
@@ -90,11 +90,11 @@ function macd(x::Array{Float64}; nfast::Int64=12, nslow::Int64=26, nsig::Int64=9
     return out
 end
 
-@doc """
-Relative strength index
+"""
+    rsi(x::Array{Float64}; n::Int64=14, ma::Function=ema, args...)::Array{Float64}
 
-`rsi(x::Array{Float64}; n::Int64=14, ma::Function=ema, args...)::Array{Float64}`
-""" ->
+Relative strength index
+"""
 function rsi(x::Array{Float64}; n::Int64=14, ma::Function=ema, args...)::Array{Float64}
     @assert n<size(x,1) && n>0 "Argument n is out of bounds."
     N = size(x,1)
@@ -113,17 +113,17 @@ function rsi(x::Array{Float64}; n::Int64=14, ma::Function=ema, args...)::Array{F
     return 100.0 .- 100.0 ./ (1.0 .+ rs)
 end
 
-@doc """
-Average directional index
+"""
+    adx(hlc::Array{Float64}; n::Int64=14, wilder=true)::Array{Float64}
 
-`adx(hlc::Array{Float64}; n::Int64=14, wilder=true)::Array{Float64}`
+Average directional index
 
 *Output*
 
 - Column 1: DI+
 - Column 2: DI-
 - Column 3: ADX
-""" ->
+"""
 function adx(hlc::Array{Float64}; n::Int64=14, ma::Function=ema, args...)::Matrix{Float64}
     @assert n<size(hlc,1) && n>0 "Argument n is out of bounds."
     if size(hlc,2) != 3
@@ -149,17 +149,17 @@ function adx(hlc::Array{Float64}; n::Int64=14, ma::Function=ema, args...)::Matri
     return [dip dim adx]
 end
 
-@doc """
-Parabolic stop and reverse (SAR)
+"""
+    psar(hl::Array{Float64}; af_min::Float64=0.02, af_max::Float64=0.2, af_inc::Float64=af_min)::Array{Float64}
 
-`psar(hl::Array{Float64}; af_min::Float64=0.02, af_max::Float64=0.2, af_inc::Float64=af_min)::Array{Float64}`
+Parabolic stop and reverse (SAR)
 
 *Arguments*
 - `hl`: 2D array of high and low prices in first and second columns respectively
 - `af_min`: starting/initial value for acceleration factor
 - `af_max`: maximum acceleration factor (accel factor capped at this value)
 - `af_inc`: increment to the acceleration factor (speed of increase in accel factor)
-""" ->
+"""
 function psar(hl::Array{Float64}; af_min::Float64=0.02, af_max::Float64=0.2, af_inc::Float64=af_min)::Array{Float64}
     @assert af_min<1.0 && af_min>0.0 "Argument af_min must be in [0,1]."
     @assert af_max<1.0 && af_max>0.0 "Argument af_max must be in [0,1]."
@@ -208,16 +208,16 @@ function psar(hl::Array{Float64}; af_min::Float64=0.02, af_max::Float64=0.2, af_
     return sar
 end
 
-@doc """
-KST (Know Sure Thing) -- smoothed and summed rates of change
-
+"""
 ```
 kst(x::Array{Float64};
     nroc::Array{Int64}=[10,15,20,30], navg::Array{Int64}=[10,10,10,15],
     wgts::Array{Int64}=collect(1:length(nroc)), ma::Function=sma)::Array{Float64}
 
 ```
-""" ->
+
+KST (Know Sure Thing) -- smoothed and summed rates of change
+"""
 function kst(x::Array{Float64}; nroc::Array{Int64}=[10,15,20,30], navg::Array{Int64}=[10,10,10,15],
              wgts::Array{Int64}=collect(1:length(nroc)), ma::Function=sma)::Array{Float64}
     @assert length(nroc) == length(navg)
@@ -232,22 +232,22 @@ function kst(x::Array{Float64}; nroc::Array{Int64}=[10,15,20,30], navg::Array{In
     return out
 end
 
-@doc """
-Williams %R
+"""
+    wpr(hlc::Array{Float64,2}, n::Int64=14)::Array{Float64}
 
-`wpr(hlc::Array{Float64,2}, n::Int64=14)::Array{Float64}`
-""" ->
+Williams %R
+"""
 function wpr(hlc::Array{Float64,2}; n::Int64=14)::Array{Float64}
     hihi = runmax(hlc[:,1], n=n, cumulative=false)
     lolo = runmin(hlc[:,2], n=n, cumulative=false)
     return -100 * (hihi - hlc[:,3]) ./ (hihi - lolo)
 end
 
-@doc """
-Commodity channel index
+"""
+    cci(hlc::Array{Float64,2}; n::Int64=20, c::Float64=0.015, ma::Function=sma)::Array{Float64}
 
-`cci(hlc::Array{Float64,2}; n::Int64=20, c::Float64=0.015, ma::Function=sma)::Array{Float64}`
-""" ->
+Commodity channel index
+"""
 function cci(hlc::Array{Float64,2}; n::Int64=20, c::Float64=0.015, ma::Function=sma, args...)::Array{Float64}
     tp = (hlc[:,1] + hlc[:,2] + hlc[:,3]) ./ 3.0
     dev = runmad(tp, n=n, cumulative=false, fun=mean)
@@ -255,11 +255,11 @@ function cci(hlc::Array{Float64,2}; n::Int64=20, c::Float64=0.015, ma::Function=
     return (tp - avg) ./ (c * dev)
 end
 
-@doc """
-Stochastic oscillator (fast or slow)
+"""
+    stoch(hlc::Array{Float64,2}; nK::Int64=14, nD::Int64=3, kind::Symbol=:fast, ma::Function=sma, args...)::Matrix{Float64}
 
-`stoch(hlc::Array{Float64,2}; nK::Int64=14, nD::Int64=3, kind::Symbol=:fast, ma::Function=sma, args...)::Matrix{Float64}`
-""" ->
+Stochastic oscillator (fast or slow)
+"""
 function stoch(hlc::Array{Float64,2}; nK::Int64=14, nD::Int64=3,
                kind::Symbol=:fast, ma::Function=sma, args...)::Matrix{Float64}
     @assert kind == :fast || kind == :slow "Argument `kind` must be either :fast or :slow"
@@ -277,14 +277,14 @@ function stoch(hlc::Array{Float64,2}; nK::Int64=14, nD::Int64=3,
     return out
 end
 
-@doc """
-SMI (stochastic momentum oscillator)
-
+"""
 ```
 smi(hlc::Array{Float64,2}; n::Int64=13, nFast::Int64=2, nSlow::Int64=25, nSig::Int64=9,
     maFast::Function=ema, maSlow::Function=ema, maSig::Function=sma)::Matrix{Float64}
 ```
-""" ->
+
+SMI (stochastic momentum oscillator)
+"""
 function smi(hlc::Array{Float64,2}; n::Int64=13, nFast::Int64=2, nSlow::Int64=25, nSig::Int64=9,
              maFast::Function=ema, maSlow::Function=ema, maSig::Function=sma)::Matrix{Float64}
     hihi = runmax(hlc[:,1], n=n, cumulative=false)

--- a/src/patterns.jl
+++ b/src/patterns.jl
@@ -1,4 +1,4 @@
-@doc """
+"""
 Renko chart patterns
 
 # Methods
@@ -10,9 +10,9 @@ Renko chart patterns
 
 `Array{Int}` object of size Nx1 (where N is the number rows in `x`) where each element gives the Renko bar number of the corresponding row in `x`.
 
-""" ->
-# Renko chart bar identification with traditional methodology (constant box size)
+"""
 function renko(x::Array{Float64}; box_size::Float64=10.0)::Array{Int}
+    # Renko chart bar identification with traditional methodology (constant box size)
     @assert box_size != 0
     "Argument `box_size` must be nonzero."
     if box_size < 0.0
@@ -29,8 +29,8 @@ function renko(x::Array{Float64}; box_size::Float64=10.0)::Array{Int}
     return bar_id
 end
 
-# Renko chart bar identification with option to use ATR or traditional method (constant box size)
 function renko(hlc::Matrix{Float64}; box_size::Float64=10.0, use_atr::Bool=false, n::Int=14)::Array{Int}
+    # Renko chart bar identification with option to use ATR or traditional method (constant box size)
     if use_atr
         bar_id = ones(Int, size(hlc,1))
         box_sizes = atr(hlc, n=n)

--- a/src/reg.jl
+++ b/src/reg.jl
@@ -1,8 +1,8 @@
 using Statistics
 
-@doc """
+"""
 Moving linear regression intercept (column 1) and slope (column 2)
-""" ->
+"""
 function mlr_beta(y::Array{Float64}; n::Int64=10, x::Array{Float64}=collect(1.0:n))::Matrix{Float64}
     @assert n<length(y) && n>0 "Argument n out of bounds."
     @assert size(y,2) == 1
@@ -21,9 +21,9 @@ function mlr_beta(y::Array{Float64}; n::Int64=10, x::Array{Float64}=collect(1.0:
     return out
 end
 
-@doc """
+"""
 Moving linear regression slope
-""" ->
+"""
 function mlr_slope(y::Array{Float64}; n::Int64=10, x::Array{Float64}=collect(1.0:n))::Array{Float64}
     @assert n<length(y) && n>0 "Argument n out of bounds."
     @assert size(y,2) == 1
@@ -39,9 +39,9 @@ function mlr_slope(y::Array{Float64}; n::Int64=10, x::Array{Float64}=collect(1.0
     return out
 end
 
-@doc """
+"""
 Moving linear regression y-intercept
-""" ->
+"""
 function mlr_intercept(y::Array{Float64}; n::Int64=10, x::Array{Float64}=collect(1.0:n))::Array{Float64}
     @assert n<length(y) && n>0 "Argument n out of bounds."
     @assert size(y,2) == 1
@@ -59,17 +59,17 @@ function mlr_intercept(y::Array{Float64}; n::Int64=10, x::Array{Float64}=collect
     return out
 end
 
-@doc """
+"""
 Moving linear regression predictions
-""" ->
+"""
 function mlr(y::Array{Float64}; n::Int64=10)::Array{Float64}
     b = mlr_beta(y, n=n)
     return b[:,1] + b[:,2]*float(n)
 end
 
-@doc """
+"""
 Moving linear regression standard errors
-""" ->
+"""
 function mlr_se(y::Array{Float64}; n::Int64=10)::Array{Float64}
     yhat = mlr(y, n=n)
     r = zeros(Float64, n)
@@ -83,21 +83,21 @@ function mlr_se(y::Array{Float64}; n::Int64=10)::Array{Float64}
     return out
 end
 
-@doc """
+"""
 Moving linear regression upper bound
-""" ->
+"""
 function mlr_ub(y::Array{Float64}; n::Int64=10, se::Float64=2.0)::Array{Float64}
     return y + se*mlr_se(y, n=n)
 end
 
-@doc """
+"""
 Moving linear regression lower bound
-""" ->
+"""
 function mlr_lb(y::Array{Float64}; n::Int64=10, se::Float64=2.0)::Array{Float64}
     return y - se*mlr_se(y, n=n)
 end
 
-@doc """
+"""
 Moving linear regression bands
 
 
@@ -108,7 +108,7 @@ Column 1: Lower bound
 Column 2: Regression estimate
 
 Column 3: Upper bound
-""" ->
+"""
 function mlr_bands(y::Array{Float64}; n::Int64=10, se::Float64=2.0)::Matrix{Float64}
     out = zeros(Float64, (length(y),3))
     out[1:n-1,:] .= NaN
@@ -118,9 +118,9 @@ function mlr_bands(y::Array{Float64}; n::Int64=10, se::Float64=2.0)::Matrix{Floa
     return out
 end
 
-@doc """
+"""
 Moving linear regression R-squared or adjusted R-squared
-""" ->
+"""
 function mlr_rsq(y::Array{Float64}; n::Int64=10, adjusted::Bool=false)::Array{Float64}
     yhat = mlr(y, n=n)
     rsq = runcor(y, yhat, n=n, cumulative=false) .^ 2

--- a/src/run.jl
+++ b/src/run.jl
@@ -2,11 +2,11 @@ import Temporal.acf  # used for running autocorrelation function
 
 using Statistics
 
-@doc """
-Lagged differencing
+"""
+    diffn(x::Array{Float64}; n::Int64=1)::Array{Float64}
 
-`diffn(x::Array{Float64}; n::Int64=1)::Array{Float64}`
-""" ->
+Lagged differencing
+"""
 function diffn(x::Array{Float64}; n::Int64=1)::Array{Float64}
     @assert n<size(x,1) && n>0 "Argument n out of bounds."
     dx = zeros(size(x))
@@ -17,11 +17,11 @@ function diffn(x::Array{Float64}; n::Int64=1)::Array{Float64}
     return dx
 end
 
-@doc """
-Lagged differencing
+"""
+    diffn(X::Array{Float64,2}; n::Int64=1)::Array{Float64}
 
-`diffn(X::Array{Float64,2}; n::Int64=1)::Array{Float64}`
-""" ->
+Lagged differencing
+"""
 function diffn(X::Array{Float64,2}; n::Int64=1)::Matrix{Float64}
     @assert n<size(X,1) && n>0 "Argument n out of bounds."
     dx = zeros(size(X))
@@ -31,11 +31,11 @@ function diffn(X::Array{Float64,2}; n::Int64=1)::Matrix{Float64}
     return dx
 end
 
-@doc """
+"""
 (Adapted from StatsBase: https://raw.githubusercontent.com/JuliaStats/StatsBase.jl/master/src/scalarstats.jl)
 
 `Compute the mode of an arbitrary array::Array{Float64}`
-""" ->
+"""
 function mode(a::AbstractArray{Float64})
     isempty(a) && error("mode: input array cannot be empty.")
     cnts = Dict{Float64,Int64}()
@@ -60,11 +60,11 @@ function mode(a::AbstractArray{Float64})
     return mv
 end
 
-@doc """
-Compute a running or rolling arithmetic mean of an array.
+"""
+    runmean(x::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}
 
-`runmean(x::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}`
-""" ->
+Compute a running or rolling arithmetic mean of an array.
+"""
 function runmean(x::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}
     @assert n<size(x,1) && n>1 "Argument n is out of bounds."
     out = zeros(size(x))
@@ -83,11 +83,11 @@ function runmean(x::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{F
 end
 
 
-@doc """
-Compute a running or rolling summation of an array.
+"""
+    runsum(x::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}
 
-`runsum(x::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}`
-""" ->
+Compute a running or rolling summation of an array.
+"""
 function runsum(x::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}
     @assert n<size(x,1) && n>1 "Argument n is out of bounds."
     if cumulative
@@ -103,11 +103,11 @@ function runsum(x::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Fl
     return out
 end
 
-@doc """
-Welles Wilder summation of an array
+"""
+    wilder_sum(x::Array{Float64}; n::Int64=10)::Array{Float64}
 
-`wilder_sum(x::Array{Float64}; n::Int64=10)::Array{Float64}`
-""" ->
+Welles Wilder summation of an array
+"""
 function wilder_sum(x::Array{Float64}; n::Int64=10)::Array{Float64}
     @assert n<size(x,1) && n>0 "Argument n is out of bounds."
     nf = float(n)  # type stability -- all arithmetic done on floats
@@ -119,11 +119,11 @@ function wilder_sum(x::Array{Float64}; n::Int64=10)::Array{Float64}
     return out
 end
 
-@doc """
-Compute the running or rolling mean absolute deviation of an array
+"""
+    runmad(x::Array{Float64}; n::Int64=10, cumulative::Bool=true, fun::Function=median)::Array{Float64}
 
-`runmad(x::Array{Float64}; n::Int64=10, cumulative::Bool=true, fun::Function=median)::Array{Float64}`
-""" ->
+Compute the running or rolling mean absolute deviation of an array
+"""
 function runmad(x::Array{Float64}; n::Int64=10, cumulative::Bool=true, fun::Function=median)::Array{Float64}
     @assert n<size(x,1) && n>1 "Argument n is out of bounds."
     out = zeros(size(x))
@@ -145,11 +145,11 @@ function runmad(x::Array{Float64}; n::Int64=10, cumulative::Bool=true, fun::Func
     return out
 end
 
-@doc """
-Compute the running or rolling variance of an array
+"""
+    runvar(x::Array{Float64}; n::Int64=10, cumulative=true)::Array{Float64}
 
-`runvar(x::Array{Float64}; n::Int64=10, cumulative=true)::Array{Float64}`
-""" ->
+Compute the running or rolling variance of an array
+"""
 function runvar(x::Array{Float64}; n::Int64=10, cumulative=true)::Array{Float64}
     @assert n<size(x,1) && n>1 "Argument n is out of bounds."
     out = zeros(size(x))
@@ -166,20 +166,20 @@ function runvar(x::Array{Float64}; n::Int64=10, cumulative=true)::Array{Float64}
     return out
 end
 
-@doc """
-Compute the running or rolling standard deviation of an array
+"""
+    runsd(x::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}
 
-`runsd(x::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}`
-""" ->
+Compute the running or rolling standard deviation of an array
+"""
 function runsd(x::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}
     return sqrt.(runvar(x, n=n, cumulative=cumulative))
 end
 
-@doc """
-Compute the running or rolling covariance of two arrays
+"""
+    runcov(x::Array{Float64}, y::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}
 
-`runcov(x::Array{Float64}, y::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}`
-""" ->
+Compute the running or rolling covariance of two arrays
+"""
 function runcov(x::Array{Float64}, y::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}
     @assert length(x) == length(y) "Dimension mismatch: length of `x` not equal to length of `y`."
     @assert n<size(x,1) && n>1 "Argument n is out of bounds."
@@ -197,11 +197,11 @@ function runcov(x::Array{Float64}, y::Array{Float64}; n::Int64=10, cumulative::B
     return out
 end
 
-@doc """
-Compute the running or rolling correlation of two arrays
+"""
+    runcor(x::Array{Float64}, y::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}
 
-`runcor(x::Array{Float64}, y::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}`
-""" ->
+Compute the running or rolling correlation of two arrays
+"""
 function runcor(x::Array{Float64}, y::Array{Float64}; n::Int64=10, cumulative::Bool=true)::Array{Float64}
     @assert length(x) == length(y) "Dimension mismatch: length of `x` not equal to length of `y`."
     @assert n<size(x,1) && n>1 "Argument n is out of bounds."
@@ -219,11 +219,11 @@ function runcor(x::Array{Float64}, y::Array{Float64}; n::Int64=10, cumulative::B
     return out
 end
 
-@doc """
-Compute the running or rolling maximum of an array
+"""
+    runmax(x::Array{Float64}; n::Int64=10, cumulative::Bool=true, inclusive::Bool=true)::Array{Float64}
 
-`runmax(x::Array{Float64}; n::Int64=10, cumulative::Bool=true, inclusive::Bool=true)::Array{Float64}`
-""" ->
+Compute the running or rolling maximum of an array
+"""
 function runmax(x::Array{Float64}; n::Int64=10, cumulative::Bool=true, inclusive::Bool=true)::Array{Float64}
     @assert n<size(x,1) && n>1 "Argument n is out of bounds."
     out = zeros(size(x))
@@ -256,11 +256,11 @@ function runmax(x::Array{Float64}; n::Int64=10, cumulative::Bool=true, inclusive
     end
 end
 
-@doc """
-Compute the running or rolling minimum of an array
+"""
+    runmin(x::Array{Float64}; n::Int64=10, cumulative::Bool=true, inclusive::Bool=true)::Array{Float64}
 
-`runmin(x::Array{Float64}; n::Int64=10, cumulative::Bool=true, inclusive::Bool=true)::Array{Float64}`
-""" ->
+Compute the running or rolling minimum of an array
+"""
 function runmin(x::Array{Float64}; n::Int64=10, cumulative::Bool=true, inclusive::Bool=true)::Array{Float64}
     @assert n<size(x,1) && n>1 "Argument n is out of bounds."
     out = zeros(size(x))
@@ -293,11 +293,11 @@ function runmin(x::Array{Float64}; n::Int64=10, cumulative::Bool=true, inclusive
     end
 end
 
-@doc """
-Compute the running/rolling quantile of an array
+"""
+    runquantile(x::Vector{Float64}; p::Float64=0.05, n::Int=10, cumulative::Bool=true)::Vector{Float64}
 
-`runquantile(x::Vector{Float64}; p::Float64=0.05, n::Int=10, cumulative::Bool=true)::Vector{Float64}`
-""" ->
+Compute the running/rolling quantile of an array
+"""
 function runquantile(x::Array{Float64}; p::Float64=0.05, n::Int=10, cumulative::Bool=true)::Array{Float64}
     @assert n<size(x,1) && n>1 "Argument n is out of bounds."
     out = zeros(Float64, (size(x,1), size(x,2)))
@@ -316,9 +316,7 @@ function runquantile(x::Array{Float64}; p::Float64=0.05, n::Int=10, cumulative::
 end
 
 
-@doc """
-Compute the running/rolling autocorrelation of a vector.
-
+"""
 ```
 function runacf(x::Array{Float64};
                 n::Int = 10,
@@ -327,7 +325,8 @@ function runacf(x::Array{Float64};
                 cumulative::Bool = true)::Matrix{Float64}
 ```
 
-""" ->
+Compute the running/rolling autocorrelation of a vector.
+"""
 function runacf(x::Array{Float64};
                 n::Int = 10,
                 maxlag::Int = n-3,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,8 @@
 # Miscellaneous utilities
 
-@doc """
+"""
 Find where `x` crosses over `y` (returns boolean vector where crossover occurs)
-""" ->
+"""
 function crossover(x::Array{Float64}, y::Array{Float64})
     @assert size(x,1) == size(y,1)
     out = falses(size(x))
@@ -12,9 +12,9 @@ function crossover(x::Array{Float64}, y::Array{Float64})
     return out
 end
 
-@doc """
+"""
 Find where `x` crosses under `y` (returns boolean vector where crossunder occurs)
-""" ->
+"""
 function crossunder(x::Array{Float64}, y::Array{Float64})
     @assert size(x,1) == size(y,1)
     out = falses(size(x))

--- a/src/vol.jl
+++ b/src/vol.jl
@@ -1,13 +1,13 @@
-@doc """
-Bollinger bands (moving average with standard deviation bands)
+"""
+    bbands(x::Array{Float64}; n::Int64=10, sigma::Float64=2.0)::Matrix{Float64}
 
-`bbands(x::Array{Float64}; n::Int64=10, sigma::Float64=2.0)::Matrix{Float64}`
+Bollinger bands (moving average with standard deviation bands)
 
 *Output*
 - Column 1: lower band
 - Column 2: middle band
 - Column 3: upper band
-""" ->
+"""
 function bbands(x::Array{Float64}; n::Int64=10, sigma::Float64=2.0, ma::Function=sma, args...)::Matrix{Float64}
     @assert n<size(x,1) && n>0 "Argument n is out of bounds."
     out = zeros(size(x,1), 3)  # cols := lower bound, ma, upper bound
@@ -18,11 +18,11 @@ function bbands(x::Array{Float64}; n::Int64=10, sigma::Float64=2.0, ma::Function
     return out
 end
 
-@doc """
-True range
+"""
+    tr(hlc::Matrix{Float64})::Array{Float64}
 
-`tr(hlc::Matrix{Float64})::Array{Float64}`
-""" ->
+True range
+"""
 function tr(hlc::Matrix{Float64})::Array{Float64}
     @assert size(hlc,2) == 3 "HLC array must have 3 columns."
     n = size(hlc,1)
@@ -34,26 +34,26 @@ function tr(hlc::Matrix{Float64})::Array{Float64}
     return out[:,1]
 end
 
-@doc """
-Average true range (uses exponential moving average)
+"""
+    atr(hlc::Matrix{Float64}; n::Int64=14)::Array{Float64}
 
-`atr(hlc::Matrix{Float64}; n::Int64=14)::Array{Float64}`
-""" ->
+Average true range (uses exponential moving average)
+"""
 function atr(hlc::Matrix{Float64}; n::Int64=14, ma::Function=ema)::Array{Float64}
     @assert n<size(hlc,1) && n>0 "Argument n out of bounds."
     return [NaN; ma(tr(hlc)[2:end], n=n)]
 end
 
-@doc """
-Keltner bands
+"""
+    keltner(hlc::Matrix{Float64}; nema::Int64=20, natr::Int64=10, mult::Int64=2)::Matrix{Float64}
 
-`keltner(hlc::Matrix{Float64}; nema::Int64=20, natr::Int64=10, mult::Int64=2)::Matrix{Float64}`
+Keltner bands
 
 *Output*
 Column 1: lower band
 Column 2: middle band
 Column 3: upper band
-""" ->
+"""
 function keltner(hlc::Array{Float64,2}; nema::Int64=20, natr::Int64=10, mult::Int64=2)::Matrix{Float64}
     @assert size(hlc,2) == 3 "HLC array must have 3 columns."
     out = zeros(size(hlc,1), 3)


### PR DESCRIPTION
Fix deprecated syntax `@doc`
Format docstring as mentioned in https://github.com/JuliaDocs/Documenter.jl/blob/master/docs/src/man/guide.md#adding-some-docstrings

Closes #14
