### PR TITLE
Performance optimizations, 10x for moving sums

### DIFF
--- a/src/run.jl
+++ b/src/run.jl
@@ -81,8 +81,11 @@ function runmean(x::Array{T}; n::Int64=10, cumulative::Bool=true)::Array{T} wher
             out[i] = sum(x[1:i])/fi[i]
         end
     else
-        @inbounds for i = n:size(x,1)
-            out[i] = mean(x[i-n+1:i])
+        s = sum(x[1:n])
+        out[n] = s / n
+        @inbounds for i = n+1:size(x,1)
+            s += x[i] - x[i-n]
+            out[i] = s / n
         end
     end
     return out

--- a/src/run.jl
+++ b/src/run.jl
@@ -87,25 +87,25 @@ function runmean(x::Array{T}; n::Int64=10, cumulative::Bool=true)::Array{T} wher
         # end
         n_current = 0
         s::T = 0
-        for i = 1:n
-            if !isnan(x[i])
+        @inbounds for i = 1:n
+            if isfinite(x[i])
                 s += x[i]
                 n_current += 1
             end
         end
         out[n] = n_current == n ? s / n : NaN
         @inbounds for i = n+1:size(x,1)
-            if !isnan(x[i])
+            if isfinite(x[i])
                 s += x[i]
                 n_current += 1
             end
-            if !isnan(x[i-n])
+            if isfinite(x[i-n])
                 s -= x[i-n]
                 n_current -= 1
             end
-            if n_current == n # n_current > 0
-                out[i] = s / n_current
-            end
+            out[i] = (n_current == n) # n_current > 0
+                ? s / n_current
+                : NaN
         end
     end
     return out
@@ -131,25 +131,25 @@ function runsum(x::Array{T}; n::Int64=10, cumulative::Bool=true)::Array{T} where
         # end
         n_current = 0
         s::T = 0
-        for i = 1:n
-            if !isnan(x[i])
+        @inbounds for i = 1:n
+            if isfinite(x[i])
                 s += x[i]
                 n_current += 1
             end
         end
         out[n] = n_current == n ? s : NaN
         @inbounds for i = n+1:size(x,1)
-            if !isnan(x[i])
+            if isfinite(x[i])
                 s += x[i]
                 n_current += 1
             end
-            if !isnan(x[i-n])
+            if isfinite(x[i-n])
                 s -= x[i-n]
                 n_current -= 1
             end
-            if n_current == n # n_current > 0
-                out[i] = s
-            end
+            out[i] = (n_current == n) # n_current > 0
+                ? s
+                : NaN
         end
     end
     return out

--- a/src/run.jl
+++ b/src/run.jl
@@ -103,9 +103,7 @@ function runmean(x::Array{T}; n::Int64=10, cumulative::Bool=true)::Array{T} wher
                 s -= x[i-n]
                 n_current -= 1
             end
-            out[i] = (n_current == n) # n_current > 0
-                ? s / n_current
-                : NaN
+            out[i] = (n_current == n) ? s / n_current : NaN
         end
     end
     return out
@@ -147,9 +145,7 @@ function runsum(x::Array{T}; n::Int64=10, cumulative::Bool=true)::Array{T} where
                 s -= x[i-n]
                 n_current -= 1
             end
-            out[i] = (n_current == n) # n_current > 0
-                ? s
-                : NaN
+            out[i] = (n_current == n) ? s : NaN
         end
     end
     return out

--- a/src/run.jl
+++ b/src/run.jl
@@ -104,8 +104,11 @@ function runsum(x::Array{T}; n::Int64=10, cumulative::Bool=true)::Array{T} where
     else
         out = zeros(size(x))
         out[1:n-1] .= NaN
-        @inbounds for i = n:size(x,1)
-            out[i] = sum(x[i-n+1:i])
+        s = sum(x[1:n])
+        out[n] = s
+        @inbounds for i = n+1:size(x,1)
+            s += x[i] - x[i-n]
+            out[i] = s
         end
     end
     return out


### PR DESCRIPTION
Though I'm not sure about floating point error accumulation.
The same thing could be done for runvar, runsd, runcov, etc.
